### PR TITLE
Add offsets

### DIFF
--- a/CRM/Civithermometer/Form/Thermometer.php
+++ b/CRM/Civithermometer/Form/Thermometer.php
@@ -23,6 +23,8 @@ class CRM_Civithermometer_Form_Thermometer extends CRM_Contribute_Form_Contribut
     $this->addField('thermometer_is_enabled');
     $this->addField('thermometer_stretch_goal');
     $this->addField('thermometer_is_double');
+    $this->addField('thermometer_offset_amount');
+    $this->addField('thermometer_offset_donors');
 
     $this->addButtons(array(
       array(

--- a/CRM/Civithermometer/Upgrader.php
+++ b/CRM/Civithermometer/Upgrader.php
@@ -60,7 +60,7 @@ class CRM_Civithermometer_Upgrader extends CRM_Civithermometer_Upgrader_Base {
   }
 
   /**
-   * Example: Run a couple simple queries.
+   * Add extension specific columns to civicrm_contribution_page table
    *
    * @return TRUE on success
    * @throws Exception
@@ -75,16 +75,18 @@ class CRM_Civithermometer_Upgrader extends CRM_Civithermometer_Upgrader_Base {
 
 
   /**
-   * Example: Run an external SQL script.
+   * Add two new columns to civicrm_contribution_page table
    *
    * @return TRUE on success
    * @throws Exception
+   */
   public function upgrade_4201() {
     $this->ctx->log->info('Applying update 4201');
-    // this path is relative to the extension base dir
-    $this->executeSqlFile('sql/upgrade_4201.sql');
+    if (!CRM_Core_DAO::checkFieldExists('civicrm_contribution_page', 'therometer_offset_amount')) {
+      $this->executeSqlFile('sql/upgrade_4201.sql');
+    }
     return TRUE;
-  } // */
+  }
 
 
   /**

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ thermometer.
 
 ## Known Issues
 
+The extension makes use of CiviCRM API v3 _and_ v4 calls. Sites running CiviCRM 5.19 or higher will have both
+installed automatically. All v3 calls will eventually be rewritten as v4 calls.
+
 The extension works by using JavaScript to get and calculate required values, then manipulate the DOM to
 render and update the thermometer. At present the extension is expecting HTML elements that possess certain
 class names. These will be documented in this file in due course.

--- a/civithermometer.php
+++ b/civithermometer.php
@@ -259,6 +259,8 @@ function civithermometer_civicrm_buildForm($formName, &$form) {
         'thermometer_is_double',
         'thermometer_stretch_goal',
         'goal_amount',
+        'thermometer_offset_amount',
+        'thermometer_offset_donors',
       ])
       ->addWhere('id', '=', $formId)
       ->setCheckPermissions(FALSE)
@@ -279,6 +281,8 @@ function civithermometer_civicrm_buildForm($formName, &$form) {
       $isDouble = $contribPage->first()['thermometer_is_double'];
       $numberDonors = $contributions->count();
       $amountRaised = 0;
+      $offsetRaised = $contribPage->first()['thermometer_offset_amount'];
+      $offsetDonors = $contribPage->first()['thermometer_offset_donors'];
 
       if ($numberDonors > 0) {
         $amounts = array_column((array) $contributions, 'total_amount');
@@ -286,6 +290,10 @@ function civithermometer_civicrm_buildForm($formName, &$form) {
           return ($a += $b);
         });
       }
+
+      // Apply offsets if defined
+      $amountRaised += $offsetRaised;
+      $numberDonors += $offsetDonors;
 
       // Get thermometer HTML and CSS
       $thermo_settings = \Civi\Api4\Setting::get()

--- a/civithermometer.php
+++ b/civithermometer.php
@@ -202,28 +202,50 @@ function civithermometer_civicrm_entityTypes(&$entityTypes) {
       'type' => 'CheckBox',
     ),
   );
-  $fields['thermometer_is_double'] = array(
-    'name' => 'thermometer_is_double',
-    'title' => E::ts('is this a double your donation thermometer? (optional)'),
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-    'entity' => 'ContributionPage',
-    'bao' => 'CRM_Contribute_BAO_ContributionPage',
-    'localizable' => 0,
-    'html' => array(
-      'type' => 'CheckBox',
-    ),
-  );
-  $fields['thermometer_stretch_goal'] = array(
-    'name' => 'thermometer_stretch_goal',
-    'title' => E::ts('Stretch goal if goal amount is reached? (optional)'),
-    'type' => CRM_Utils_Type::T_MONEY,
-    'entity' => 'ContributionPage',
-    'bao' => 'CRM_Contribute_BAO_ContributionPage',
-    'localizable' => 0,
-    'html' => array(
-      'type' => 'Text',
-    ),
-  );
+    $fields['thermometer_is_double'] = array(
+      'name' => 'thermometer_is_double',
+      'title' => E::ts('Is this a double your donation thermometer? (optional)'),
+      'type' => CRM_Utils_Type::T_BOOLEAN,
+      'entity' => 'ContributionPage',
+      'bao' => 'CRM_Contribute_BAO_ContributionPage',
+      'localizable' => 0,
+      'html' => array(
+        'type' => 'CheckBox',
+      ),
+    );
+    $fields['thermometer_stretch_goal'] = array(
+      'name' => 'thermometer_stretch_goal',
+      'title' => E::ts('Stretch goal if goal amount is reached? (optional)'),
+      'type' => CRM_Utils_Type::T_MONEY,
+      'entity' => 'ContributionPage',
+      'bao' => 'CRM_Contribute_BAO_ContributionPage',
+      'localizable' => 0,
+      'html' => array(
+        'type' => 'Text',
+      ),
+    );
+    $fields['thermometer_offset_amount'] = array(
+      'name' => 'thermometer_offset_amount',
+      'title' => E::ts('Amount to offset existing contribution total? (optional)'),
+      'type' => CRM_Utils_Type::T_MONEY,
+      'entity' => 'ContributionPage',
+      'bao' => 'CRM_Contribute_BAO_ContributionPage',
+      'localizable' => 0,
+      'html' => array(
+        'type' => 'Text',
+      ),
+    );
+    $fields['thermometer_offset_donors'] = array(
+      'name' => 'thermometer_offset_donors',
+      'title' => E::ts('Amount to offset existing number of contributors? (optional)'),
+      'type' => CRM_Utils_Type::T_MONEY,
+      'entity' => 'ContributionPage',
+      'bao' => 'CRM_Contribute_BAO_ContributionPage',
+      'localizable' => 0,
+      'html' => array(
+        'type' => 'Text',
+      ),
+    );
   };
 }
 

--- a/civithermometer.php
+++ b/civithermometer.php
@@ -192,16 +192,16 @@ function civithermometer_civicrm_tabset($tabsetName, &$tabs, $context) {
 function civithermometer_civicrm_entityTypes(&$entityTypes) {
   $entityTypes['CRM_Contribute_DAO_ContributionPage']['fields_callback'][] = function($class, &$fields) {
     $fields['thermometer_is_enabled'] = array(
-    'name' => 'thermometer_is_enabled',
-    'title' => E::ts('Add thermometer to the page'),
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-    'entity' => 'ContributionPage',
-    'bao' => 'CRM_Contribute_BAO_ContributionPage',
-    'localizable' => 0,
-    'html' => array(
-      'type' => 'CheckBox',
-    ),
-  );
+      'name' => 'thermometer_is_enabled',
+      'title' => E::ts('Add thermometer to the page'),
+      'type' => CRM_Utils_Type::T_BOOLEAN,
+      'entity' => 'ContributionPage',
+      'bao' => 'CRM_Contribute_BAO_ContributionPage',
+      'localizable' => 0,
+      'html' => array(
+        'type' => 'CheckBox',
+      ),
+    );
     $fields['thermometer_is_double'] = array(
       'name' => 'thermometer_is_double',
       'title' => E::ts('Is this a double your donation thermometer? (optional)'),
@@ -238,7 +238,7 @@ function civithermometer_civicrm_entityTypes(&$entityTypes) {
     $fields['thermometer_offset_donors'] = array(
       'name' => 'thermometer_offset_donors',
       'title' => E::ts('Amount to offset existing number of contributors? (optional)'),
-      'type' => CRM_Utils_Type::T_MONEY,
+      'type' => CRM_Utils_Type::T_INT,
       'entity' => 'ContributionPage',
       'bao' => 'CRM_Contribute_BAO_ContributionPage',
       'localizable' => 0,

--- a/civithermometer.php
+++ b/civithermometer.php
@@ -226,7 +226,7 @@ function civithermometer_civicrm_entityTypes(&$entityTypes) {
     );
     $fields['thermometer_offset_amount'] = array(
       'name' => 'thermometer_offset_amount',
-      'title' => E::ts('Amount to offset existing contribution total? (optional)'),
+      'title' => E::ts('Adjust existing contribution total? (optional; use negative numbers to subtract)'),
       'type' => CRM_Utils_Type::T_MONEY,
       'entity' => 'ContributionPage',
       'bao' => 'CRM_Contribute_BAO_ContributionPage',
@@ -237,7 +237,7 @@ function civithermometer_civicrm_entityTypes(&$entityTypes) {
     );
     $fields['thermometer_offset_donors'] = array(
       'name' => 'thermometer_offset_donors',
-      'title' => E::ts('Amount to offset existing number of contributors? (optional)'),
+      'title' => E::ts('Adjust existing number of contributors? (optional; use negative numbers to subtract)'),
       'type' => CRM_Utils_Type::T_INT,
       'entity' => 'ContributionPage',
       'bao' => 'CRM_Contribute_BAO_ContributionPage',

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2019-12-03</releaseDate>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.19</ver>

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,3 +1,5 @@
 ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_is_enabled tinyint unsigned DEFAULT NULL COMMENT 'Does the contribution page use a thermometer';
-ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_is_double tinyint unsigned DEFAULT NULL COMMENT 'is the thermometer a double your money one';
+ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_is_double tinyint unsigned DEFAULT NULL COMMENT 'Is the thermometer a double your money one';
 ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_stretch_goal decimal(20,2) COMMENT 'Stretch goal for the thermometer';
+ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_offset_amount decimal(20,2) COMMENT 'Offset for amount of money raised';
+ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_offset_donors INTEGER COMMENT 'Offset for number of contributors';

--- a/sql/upgrade_4201.sql
+++ b/sql/upgrade_4201.sql
@@ -1,0 +1,2 @@
+ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_offset_amount decimal(20,2) COMMENT 'Offset for amount of money raised';
+ALTER TABLE civicrm_contribution_page ADD COLUMN thermometer_offset_donors INTEGER COMMENT 'Offset for number of contributors';


### PR DESCRIPTION
This PR adds in functionality to modify the amount of money raised and number of contributors on any contribution page using the thermometer. This is useful if you intend to "recycle" a contribution page for multiple campaigns. You can offset the existing contributions to effectively reset the thermometer back to zero.