### PR TITLE
Fix double donations mode

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,9 +14,9 @@
     <url desc="Support">https://github.com/australiangreens/civithermometer</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-04-23</releaseDate>
-  <version>1.0.0</version>
-  <develStage>beta</develStage>
+  <releaseDate>2024-05-28</releaseDate>
+  <version>1.0.1</version>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>5.70</ver>
   </compatibility>

--- a/js/civithermo.js
+++ b/js/civithermo.js
@@ -5,7 +5,7 @@ function civithermo_render() {
   const raised = parseInt(CRM.vars.civithermo.amountRaised);
   const currency = CRM.vars.civithermo.currency;
   const donors = CRM.vars.civithermo.numberDonors;
-  const isDouble = parseInt(CRM.vars.civithermo.isDouble);
+  const isDouble = CRM.vars.civithermo.isDouble;
 
   // Declare thermometer elements
   let thermo_target = document.getElementsByClassName('civithermo_target')[0];

--- a/templates/CRM/Civithermometer/Form/ThermoAdmin.tpl
+++ b/templates/CRM/Civithermometer/Form/ThermoAdmin.tpl
@@ -12,11 +12,6 @@
   </div>
 {/foreach}
 
-  <div>
-    <span>{$form.favorite_color.label}</span>
-    <span>{$form.favorite_color.html}</span>
-  </div>
-
 {* FOOTER *}
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
This PR fixes the double donation mode and removes some boilerplate template code that was hanging around after `civix generate:form`.

This has been tested and it restores the functionality of the double donation mode as desired.