### PR TITLE
Fix insertion order of JS assets

### DIFF
--- a/civithermometer.php
+++ b/civithermometer.php
@@ -223,8 +223,8 @@ function civithermometer_civicrm_buildForm($formName, &$form) {
       }
 
       CRM_Core_Resources::singleton()->addStyle($css);
-      CRM_Core_Resources::singleton()->addScriptFile('civithermometer', 'js/civithermo.js');
-      CRM_Core_Resources::singleton()->addScript('civithermo_render();');
+      CRM_Core_Resources::singleton()->addScriptFile('civithermometer', 'js/civithermo.js', ['weight' => 0]);
+      CRM_Core_Resources::singleton()->addScript('civithermo_render();', ['weight' => 10]);
     }
   }
 }

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/civithermometer</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-05-28</releaseDate>
-  <version>1.0.1</version>
+  <releaseDate>2024-07-08</releaseDate>
+  <version>1.0.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.70</ver>


### PR DESCRIPTION
This PR guarantees that the insertion of the `civithermo_render()` call happens _after_ the script file containing the `civithermo_render` code has been inserted into the rendered form.

Tested, working, etc.