### PR TITLE
Ryver #HELP-4496: Fix percentage figure when donations are doubled

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/civithermometer</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-10-10</releaseDate>
-  <version>2.0.0</version>
+  <releaseDate>2025-03-21</releaseDate>
+  <version>2.0.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.75</ver>

--- a/js/civithermo.js
+++ b/js/civithermo.js
@@ -37,6 +37,7 @@ function civithermo_render() {
     thermo_total.innerHTML = raised.toLocaleString(locale, {style: 'currency', currency: currency, minimumFractionDigits: 0})
       + ' DONATED MEANS <br />'
       + (2 * raised).toLocaleString(locale, {style: 'currency', currency: currency, minimumFractionDigits: 0}) + ' SO FAR';
+    thermo_percent = thermo_percent * 2;
   } else {
     thermo_total.innerHTML = raised.toLocaleString(locale, {style: 'currency', currency: currency, minimumFractionDigits: 0}) + ' SO FAR';
   }


### PR DESCRIPTION
See Ryver #HELP-4496

Donation %age is being calculated incorrectly in the case where the raised donations are being doubled.

This PR ensures that the %age raised is doubled if the donations are doubled, thus producing the correct figure.

This has only been tested in my JS console on my browser.